### PR TITLE
Add PyTorch Lightning training pipeline for MAE

### DIFF
--- a/mae/configs/train_mae.yaml
+++ b/mae/configs/train_mae.yaml
@@ -1,0 +1,23 @@
+data:
+  train_dir: /path/to/train
+  val_dir: /path/to/val
+  image_size: 224
+  num_workers: 8
+  batch_size: 64
+
+optim:
+  lr: 1.5e-4
+  weight_decay: 0.05
+  betas: [0.9, 0.95]
+  warmup_epochs: 10
+  max_epochs: 200
+  mask_ratio: 0.75
+
+trainer:
+  devices: 4
+  accelerator: "gpu"
+  strategy: "ddp"
+  precision: "16-mixed"
+  log_every_n_steps: 50
+  default_root_dir: ./outputs/mae_runs
+  gradient_clip_val: 1.0

--- a/mae/lightning/data/background_dataset.py
+++ b/mae/lightning/data/background_dataset.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from PIL import Image
+from torch.utils.data import Dataset
+from torchvision import transforms
+
+
+class BackgroundOnlyDataset(Dataset):
+    """Dataset that loads images from a directory without labels.
+
+    All ``.png`` and ``.jpg`` files under ``root`` will be loaded. Each image
+    undergoes a series of augmentations and is returned as a tensor in
+    ``[C, H, W]`` format within ``[0, 1]`` range.
+    """
+
+    def __init__(self, root: str | Path, image_size: int = 224) -> None:
+        self.root = Path(root)
+        if not self.root.is_dir():
+            raise ValueError(f"Root directory {root} does not exist")
+
+        # Collect image file paths
+        exts = ("*.png", "*.jpg", "*.jpeg")
+        self.files: List[Path] = []
+        for ext in exts:
+            self.files.extend(sorted(self.root.rglob(ext)))
+        if not self.files:
+            raise RuntimeError(f"No images found in {root}")
+
+        self.transform = transforms.Compose(
+            [
+                transforms.RandomResizedCrop(image_size),
+                transforms.RandomHorizontalFlip(),
+                transforms.ColorJitter(
+                    brightness=0.2, contrast=0.2, saturation=0.05, hue=0.02
+                ),
+                transforms.ToTensor(),
+            ]
+        )
+
+    def __len__(self) -> int:  # pragma: no cover - simple delegation
+        return len(self.files)
+
+    def __getitem__(self, index: int):
+        path = self.files[index]
+        with Image.open(path) as img:
+            img = img.convert("RGB")
+            return self.transform(img)

--- a/mae/lightning/models/mae_lightning.py
+++ b/mae/lightning/models/mae_lightning.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Tuple
+
+import pytorch_lightning as pl
+import torch
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import LambdaLR
+
+from models_mae import mae_vit_base_patch16
+
+
+class MAELightning(pl.LightningModule):
+    """PyTorch Lightning module wrapping the official MAE model."""
+
+    def __init__(
+        self,
+        mask_ratio: float = 0.75,
+        lr: float = 1.5e-4,
+        weight_decay: float = 0.05,
+        betas: Tuple[float, float] = (0.9, 0.95),
+        warmup_epochs: int = 10,
+        max_epochs: int = 200,
+        batch_size: int = 64,
+    ) -> None:
+        super().__init__()
+        self.save_hyperparameters()
+
+        self.model = mae_vit_base_patch16()
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return self.model(x, mask_ratio=self.hparams.mask_ratio)
+
+    def training_step(self, batch: torch.Tensor, batch_idx: int) -> torch.Tensor:
+        loss, _, _ = self(batch)
+        self.log("train_loss", loss, on_step=True, on_epoch=True, prog_bar=True)
+        return loss
+
+    def validation_step(self, batch: torch.Tensor, batch_idx: int) -> None:
+        loss, _, _ = self(batch)
+        self.log("val_loss", loss, on_epoch=True, prog_bar=True)
+
+    def configure_optimizers(self) -> Any:
+        optimizer = AdamW(
+            self.parameters(),
+            lr=self.hparams.lr,
+            betas=self.hparams.betas,
+            weight_decay=self.hparams.weight_decay,
+        )
+
+        def lr_lambda(epoch: int) -> float:
+            warmup = self.hparams.warmup_epochs
+            max_epochs = self.hparams.max_epochs
+            if epoch < warmup:
+                return float(epoch + 1) / float(warmup)
+            progress = (epoch - warmup) / max(1, max_epochs - warmup)
+            return 0.5 * (1.0 + math.cos(math.pi * progress))
+
+        scheduler = LambdaLR(optimizer, lr_lambda=lr_lambda)
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {"scheduler": scheduler, "interval": "epoch"},
+        }

--- a/mae/lightning/train.py
+++ b/mae/lightning/train.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pytorch_lightning as pl
+from omegaconf import OmegaConf
+from torch.utils.data import DataLoader
+
+# Ensure project root is on path when running as a script
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from mae.lightning.data.background_dataset import BackgroundOnlyDataset
+from mae.lightning.models.mae_lightning import MAELightning
+from mae.lightning.utils.common import log_config, set_seed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train MAE with Lightning")
+    parser.add_argument("--config", type=str, required=True, help="Path to YAML config")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    args = parser.parse_args()
+
+    cfg = OmegaConf.load(args.config)
+    set_seed(args.seed)
+    log_config(cfg)
+
+    train_ds = BackgroundOnlyDataset(cfg.data.train_dir, cfg.data.image_size)
+    val_ds = BackgroundOnlyDataset(cfg.data.val_dir, cfg.data.image_size)
+
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=cfg.data.batch_size,
+        num_workers=cfg.data.num_workers,
+        shuffle=True,
+        pin_memory=True,
+        drop_last=True,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=cfg.data.batch_size,
+        num_workers=cfg.data.num_workers,
+        shuffle=False,
+        pin_memory=True,
+    )
+
+    model = MAELightning(
+        mask_ratio=cfg.optim.mask_ratio,
+        lr=cfg.optim.lr,
+        weight_decay=cfg.optim.weight_decay,
+        betas=tuple(cfg.optim.betas),
+        warmup_epochs=cfg.optim.warmup_epochs,
+        max_epochs=cfg.optim.max_epochs,
+        batch_size=cfg.data.batch_size,
+    )
+
+    trainer = pl.Trainer(max_epochs=cfg.optim.max_epochs, **cfg.trainer)
+    trainer.fit(model, train_loader, val_loader)
+
+
+if __name__ == "__main__":
+    main()

--- a/mae/lightning/utils/common.py
+++ b/mae/lightning/utils/common.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import random
+
+import numpy as np
+import torch
+from omegaconf import OmegaConf
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def log_config(cfg) -> None:
+    """Pretty print configuration to stdout."""
+    print(OmegaConf.to_yaml(cfg))


### PR DESCRIPTION
## Summary
- add BackgroundOnlyDataset with image augmentations
- implement MAELightning wrapper with AdamW and cosine LR schedule
- create training script using PyTorch Lightning and YAML config

## Testing
- `python -m py_compile mae/lightning/data/background_dataset.py mae/lightning/models/mae_lightning.py mae/lightning/train.py mae/lightning/utils/common.py`


------
https://chatgpt.com/codex/tasks/task_e_68c485f13d188326b5d9317a770cb30c