### PR TITLE
Use dataset splits driven by config

### DIFF
--- a/mae/configs/train_mae.yaml
+++ b/mae/configs/train_mae.yaml
@@ -1,6 +1,8 @@
+seed: 0
+
 data:
-  train_dir: /path/to/train
-  val_dir: /path/to/val
+  data_dir: /path/to/data
+  val_split: 0.2
   image_size: 224
   num_workers: 8
   batch_size: 64


### PR DESCRIPTION
## Summary
- replace separate train/val dirs with single `data_dir` and `val_split`
- use `random_split` with a seeded generator for reproducible train/val sets
- centralize seeding in config

## Testing
- `python -m py_compile mae/lightning/train.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c48f4cd1e083268c8271ce06488b16