### PR TITLE
Add OrbitGen dataset support for YOLO training

### DIFF
--- a/ultralytics/cfgs/orbitgen_yolov8.yaml
+++ b/ultralytics/cfgs/orbitgen_yolov8.yaml
@@ -1,0 +1,8 @@
+# OrbitGen dataset configuration for YOLOv8
+path: /path/to/orbitgen_dataset
+train: images/train
+val: images/val
+test: images/test
+keypoints: 128
+nc: 1
+mask: true

--- a/ultralytics/nn/datasets/__init__.py
+++ b/ultralytics/nn/datasets/__init__.py
@@ -1,0 +1,4 @@
+"""Custom dataset modules for Ultralytics models."""
+from .orbitgen_dataset import OrbitGenDataset
+
+__all__ = ["OrbitGenDataset"]

--- a/ultralytics/nn/datasets/orbitgen_dataset.py
+++ b/ultralytics/nn/datasets/orbitgen_dataset.py
@@ -1,0 +1,91 @@
+"""OrbitGen dataset loader for Ultralytics models."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+
+class OrbitGenDataset(Dataset):
+    """Dataset for OrbitGen-generated samples.
+
+    Each sample is expected to have an RGB image, optional mask, and a JSON
+    metadata file containing bounding boxes and keypoints. Bounding boxes are
+    returned in YOLO ``xywh`` format normalized to ``[0, 1]``. Keypoints are
+    returned as ``[x, y, v]`` triplets also normalized to ``[0, 1]``.
+    """
+
+    def __init__(self, root_dir: str | Path, img_size: int = 640) -> None:
+        self.root = Path(root_dir)
+        self.img_size = img_size
+        self.img_dir = self.root / "images"
+        self.mask_dir = self.root / "masks"
+        self.meta_dir = self.root / "meta"
+        self.images = sorted(self.img_dir.glob("*.png"))
+
+    def __len__(self) -> int:  # noqa: D401 - standard Dataset API
+        return len(self.images)
+
+    def _load_meta(self, stem: str) -> Dict[str, Any]:
+        """Load metadata JSON for an item, handling optional ``meta_`` prefix."""
+        meta_path = self.meta_dir / f"meta_{stem}.json"
+        if not meta_path.exists():
+            meta_path = self.meta_dir / f"{stem}.json"
+        with meta_path.open() as f:
+            return json.load(f)
+
+    def __getitem__(self, index: int) -> Dict[str, Any]:  # noqa: D401 - standard Dataset API
+        img_path = self.images[index]
+        stem = img_path.stem
+
+        img = Image.open(img_path).convert("RGB")
+        w, h = img.size
+        img = img.resize((self.img_size, self.img_size))
+        img_tensor = torch.from_numpy(np.array(img)).permute(2, 0, 1).float() / 255.0
+
+        mask_tensor = torch.zeros(1, self.img_size, self.img_size, dtype=torch.float32)
+        mask_path = self.mask_dir / f"{stem}.png"
+        if mask_path.exists():
+            mask = Image.open(mask_path).convert("L").resize((self.img_size, self.img_size))
+            mask_tensor = torch.from_numpy(np.array(mask)).unsqueeze(0).float() / 255.0
+
+        meta = self._load_meta(stem)
+        bboxes = []
+        for cls_id, bbox in enumerate(meta.get("bboxes", {}).values()):
+            xmin, ymin = bbox["xmin"], bbox["ymin"]
+            xmax, ymax = bbox["xmax"], bbox["ymax"]
+            xc = ((xmin + xmax) / 2) / w
+            yc = ((ymin + ymax) / 2) / h
+            bw = (xmax - xmin) / w
+            bh = (ymax - ymin) / h
+            bboxes.append([float(cls_id), xc, yc, bw, bh])
+        bbox_tensor = (
+            torch.tensor(bboxes, dtype=torch.float32) if bboxes else torch.zeros((0, 5), dtype=torch.float32)
+        )
+
+        kp_list = meta.get("keypoints", [])
+        vis_list = meta.get("keypoint_visibility", [])
+        kpts = []
+        for i, (x, y) in enumerate(kp_list):
+            v = float(vis_list[i]) if i < len(vis_list) else 1.0
+            if x > 1 or y > 1:  # assume pixel coordinates if >1
+                x /= w
+                y /= h
+            kpts.append([x, y, v])
+        if kpts:
+            kpt_tensor = torch.tensor([kpts], dtype=torch.float32)
+        else:
+            kpt_tensor = torch.zeros((bbox_tensor.shape[0], 0, 3), dtype=torch.float32)
+
+        return {
+            "img": img_tensor,
+            "bboxes": bbox_tensor,
+            "keypoints": kpt_tensor,
+            "mask": mask_tensor,
+            "meta": meta,
+        }

--- a/ultralytics/nn/utils/__init__.py
+++ b/ultralytics/nn/utils/__init__.py
@@ -1,0 +1,4 @@
+"""Utility helpers for Ultralytics custom components."""
+from .collate import orbitgen_collate_fn
+
+__all__ = ["orbitgen_collate_fn"]

--- a/ultralytics/nn/utils/collate.py
+++ b/ultralytics/nn/utils/collate.py
@@ -1,0 +1,37 @@
+"""Collate functions for custom datasets."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+import torch
+
+
+def orbitgen_collate_fn(batch: List[Dict]):
+    """Collate a batch of OrbitGen samples for YOLO training."""
+    imgs = torch.stack([b["img"] for b in batch], 0)
+    masks = None
+    if batch[0].get("mask") is not None:
+        masks = torch.stack([b["mask"] for b in batch], 0)
+
+    bboxes = []
+    keypoints = []
+    metas = []
+    for i, sample in enumerate(batch):
+        n = sample["bboxes"].shape[0]
+        if n:
+            batch_idx = torch.full((n, 1), i, dtype=sample["bboxes"].dtype)
+            bboxes.append(torch.cat([batch_idx, sample["bboxes"]], dim=1))
+            if sample["keypoints"].numel():
+                keypoints.append(sample["keypoints"])
+        metas.append(sample["meta"])
+
+    bbox_tensor = torch.cat(bboxes, 0) if bboxes else torch.zeros((0, 6), dtype=torch.float32)
+    if keypoints:
+        kpt_tensor = torch.cat(keypoints, 0)
+    else:
+        kpt_tensor = torch.zeros((0, batch[0]["keypoints"].shape[1] if batch[0]["keypoints"].ndim > 1 else 0, 3), dtype=torch.float32)
+
+    out = {"img": imgs, "bboxes": bbox_tensor, "keypoints": kpt_tensor, "meta": metas}
+    if masks is not None:
+        out["mask"] = masks
+    return out

--- a/ultralytics/tools/train_mae_yolov8.py
+++ b/ultralytics/tools/train_mae_yolov8.py
@@ -3,15 +3,30 @@ import argparse
 from ultralytics import YOLO
 
 
+def _orbitgen_loader(data_path, img_size, batch_size):
+    """Create a DataLoader for OrbitGen datasets."""
+    from torch.utils.data import DataLoader
+
+    from ultralytics.nn.datasets.orbitgen_dataset import OrbitGenDataset
+    from ultralytics.nn.utils.collate import orbitgen_collate_fn
+
+    dataset = OrbitGenDataset(data_path, img_size=img_size)
+    return DataLoader(dataset, batch_size=batch_size, shuffle=True, collate_fn=orbitgen_collate_fn)
+
+
 def main(opt):
     model = YOLO(opt.model)
-    model.train(
-        data=opt.data,
-        imgsz=opt.img,
-        epochs=opt.epochs,
-        batch=opt.batch,
-        device=opt.device,
-    )
+    if opt.orbitgen:
+        train_loader = _orbitgen_loader(opt.data, opt.img, opt.batch)
+        model.train(dataloader=train_loader, imgsz=opt.img, epochs=opt.epochs, device=opt.device)
+    else:
+        model.train(
+            data=opt.data,
+            imgsz=opt.img,
+            epochs=opt.epochs,
+            batch=opt.batch,
+            device=opt.device,
+        )
 
 
 if __name__ == "__main__":
@@ -22,4 +37,5 @@ if __name__ == "__main__":
     parser.add_argument("--epochs", type=int, default=50)
     parser.add_argument("--batch", type=int, default=16)
     parser.add_argument("--device", type=str, default="0")
+    parser.add_argument("--orbitgen", action="store_true", help="Use OrbitGen dataset")
     main(parser.parse_args())


### PR DESCRIPTION
## Summary
- add OrbitGenDataset and collate function to handle OrbitGen images, masks, bboxes, and keypoints
- enable train_mae_yolov8.py to optionally train using the OrbitGen dataloader
- provide OrbitGen dataset configuration template

## Testing
- `python -m py_compile ultralytics/nn/datasets/orbitgen_dataset.py ultralytics/nn/utils/collate.py ultralytics/tools/train_mae_yolov8.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7884fed608326a9d81e7eebe5f928