### PR TITLE
Enable MAE YOLO YAML training

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,15 @@ Use the utilities under `ultralytics_mae/tools` to compose and train a YOLO dete
      --out model_weights/mae_yolov8n_full.pt
    ```
 3. Run `python tools/json_to_yolo.py --data_yaml ultralytics_mae/cfgs/orbitgen_yolov8.yaml --output /datasets/outdir` before training to materialize YOLO label files (adjust the `--output` path to your dataset root).
-4. Launch Ultralytics training directly from the saved `.pt` file:
+4. Launch Ultralytics training directly from either the composed `.pt` file or the YAML definition:
    ```bash
    python ultralytics_mae/tools/train_mae_yolov8.py \
-     --model model_weights/mae_yolov8n_full.pt \
+     --model ultralytics_mae/cfgs/mae_yolov8n.yaml \
      --data ultralytics_mae/cfgs/orbitgen_yolov8.yaml \
-     --img 1024 --epochs 50 --batch 16 --device 0,1,2,3
+     --img 1024 --epochs 50 --batch 16 --device 0,1,2,3 --orbitgen
    ```
 
-The `.pt` checkpoint contains the full model definition, so the standard Ultralytics training CLI works without any custom YAML parsing or monkey-patching.
+The repository ships a lightweight wrapper around the pip `ultralytics` package that imports `ultralytics_mae.nn` on start-up and injects `MaeViTBackbone`, `MaeSimpleFPN`, and the `MaeDetect` head into `ultralytics.nn.tasks.globals()`. Any new custom modules can be added by exposing them in `ultralytics_mae/nn/__init__.py` and updating `register_ultralytics_modules()` so they are discoverable when Ultralytics parses a YAML model.
 
 ### License
 

--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,0 +1,39 @@
+"""Local wrapper around the installed Ultralytics package with MAE registry patches."""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from types import ModuleType
+
+
+def _load_base_package() -> ModuleType:
+    """Load the real ``ultralytics`` package from site-packages."""
+    search_paths = sys.path[1:]  # skip current working directory
+    spec = importlib.machinery.PathFinder.find_spec(__name__, search_paths)
+    if spec is None or spec.loader is None:
+        raise ImportError("Unable to locate the installed 'ultralytics' package")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[__name__] = module  # ensure relative imports inside package succeed
+    spec.loader.exec_module(module)
+    return module
+
+
+_base_pkg = _load_base_package()
+
+
+def _register_mae_modules() -> None:
+    """Inject MAE components into Ultralytics' registry if available."""
+    try:
+        from ultralytics_mae.nn import register_ultralytics_modules
+    except Exception:  # pragma: no cover - defensive against optional dependency issues
+        return
+
+    register_ultralytics_modules()
+
+
+_register_mae_modules()
+
+# Re-export public attributes from the real package
+globals().update(_base_pkg.__dict__)

--- a/ultralytics/nn/__init__.py
+++ b/ultralytics/nn/__init__.py
@@ -1,0 +1,35 @@
+"""Wrapper for :mod:`ultralytics.nn` that adds MAE modules to YOLO's registry."""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from types import ModuleType
+
+
+def _load_base_nn() -> ModuleType:
+    """Load the installed ``ultralytics.nn`` package."""
+    search_paths = sys.path[1:]
+    spec = importlib.machinery.PathFinder.find_spec(__name__, search_paths)
+    if spec is None or spec.loader is None:
+        raise ImportError("Unable to locate the installed 'ultralytics.nn' package")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[__name__] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _register_mae_modules() -> None:
+    try:
+        from ultralytics_mae.nn import register_ultralytics_modules
+    except Exception:  # pragma: no cover - fallback if MAE extras unavailable
+        return
+
+    register_ultralytics_modules()
+
+
+_base_nn = _load_base_nn()
+_register_mae_modules()
+
+globals().update(_base_nn.__dict__)

--- a/ultralytics_mae/__init__.py
+++ b/ultralytics_mae/__init__.py
@@ -1,0 +1,9 @@
+"""Ultralytics MAE integration utilities."""
+from __future__ import annotations
+
+from .nn import MaeDetect, MaeSimpleFPN, MaeViTBackbone, register_ultralytics_modules
+
+__all__ = ["MaeDetect", "MaeSimpleFPN", "MaeViTBackbone", "register_ultralytics_modules"]
+
+# Ensure the MAE modules are registered as soon as the package is imported.
+register_ultralytics_modules()

--- a/ultralytics_mae/cfgs/mae_yolov8n.yaml
+++ b/ultralytics_mae/cfgs/mae_yolov8n.yaml
@@ -1,19 +1,7 @@
-# mae + yolov8n detect-head
+# MAE-initialized YOLOv8 nano model definition.
+nc: 1
 backbone:
-  type: MaeViTBackbone
-  args:
-    ckpt_path: /abs/path/to/mae_backbone.ckpt
-    embed_dim: 768
-    patch_size: 16
-    freeze: False
-
-neck:
-  type: MaeSimpleFPN
-  args:
-    out_channels: 256
-
+  - [-1, 1, MaeViTBackbone, [null, 768, 16, false]]
 head:
-  type: Detect
-  args:
-    nc: 1
-    ch: [256, 256, 256]
+  - [-1, 1, MaeSimpleFPN, [768, 256]]
+  - [-1, 1, MaeDetect, [1, [256, 256, 256], [8, 16, 32]]]

--- a/ultralytics_mae/nn/__init__.py
+++ b/ultralytics_mae/nn/__init__.py
@@ -1,0 +1,20 @@
+"""MAE extensions for Ultralytics YOLO models."""
+from __future__ import annotations
+
+from .backbones import MaeViTBackbone
+from .modules import MaeDetect
+from .necks import MaeSimpleFPN
+
+__all__ = ["MaeViTBackbone", "MaeSimpleFPN", "MaeDetect", "register_ultralytics_modules"]
+
+
+def register_ultralytics_modules() -> None:
+    """Register custom MAE modules with Ultralytics' YAML parser."""
+    try:
+        from ultralytics.nn import tasks
+    except Exception:  # pragma: no cover - Ultralytics optional during docs/tests
+        return
+
+    tasks.MaeViTBackbone = MaeViTBackbone
+    tasks.MaeSimpleFPN = MaeSimpleFPN
+    tasks.MaeDetect = MaeDetect

--- a/ultralytics_mae/nn/backbones/__init__.py
+++ b/ultralytics_mae/nn/backbones/__init__.py
@@ -1,0 +1,6 @@
+"""Backbone modules provided by ``ultralytics_mae``."""
+from __future__ import annotations
+
+from .mae_vit import MaeViTBackbone
+
+__all__ = ["MaeViTBackbone"]

--- a/ultralytics_mae/nn/modules/__init__.py
+++ b/ultralytics_mae/nn/modules/__init__.py
@@ -1,0 +1,16 @@
+"""Additional modules used to integrate MAE features with Ultralytics."""
+from __future__ import annotations
+
+from .mae_detect import MaeDetect
+from .mae_adapter import (
+    check_divisible,
+    interpolate_pos_embed,
+    tokens_to_feature_map,
+)
+
+__all__ = [
+    "MaeDetect",
+    "check_divisible",
+    "interpolate_pos_embed",
+    "tokens_to_feature_map",
+]

--- a/ultralytics_mae/nn/modules/mae_detect.py
+++ b/ultralytics_mae/nn/modules/mae_detect.py
@@ -1,0 +1,20 @@
+"""Custom detection head wrapper for MAE-based YOLO models."""
+from __future__ import annotations
+
+import torch
+
+from ultralytics.nn.modules.head import Detect
+
+
+class MaeDetect(Detect):
+    """Thin wrapper around :class:`~ultralytics.nn.modules.head.Detect` with explicit channel metadata."""
+
+    def __init__(self, nc: int, ch: list[int], stride: list[int] | None = None) -> None:
+        super().__init__(nc=nc, ch=tuple(ch))
+        if stride is not None:
+            stride_tensor = torch.as_tensor(stride, dtype=torch.float32)
+            if stride_tensor.numel() != self.nl:
+                raise ValueError(
+                    f"stride list must match number of detection layers ({self.nl}); got {stride_tensor.numel()} entries"
+                )
+            self.stride = stride_tensor

--- a/ultralytics_mae/nn/necks/__init__.py
+++ b/ultralytics_mae/nn/necks/__init__.py
@@ -1,0 +1,6 @@
+"""Neck modules provided by ``ultralytics_mae``."""
+from __future__ import annotations
+
+from .mae_fpn import MaeSimpleFPN
+
+__all__ = ["MaeSimpleFPN"]

--- a/ultralytics_mae/tools/train_mae_yolov8.py
+++ b/ultralytics_mae/tools/train_mae_yolov8.py
@@ -1,4 +1,4 @@
-"""Training entry point for MAE-initialized YOLO models saved as .pt checkpoints."""
+"""Training entry point for MAE-initialized YOLO models."""
 
 import argparse
 from pathlib import Path
@@ -8,8 +8,8 @@ from ultralytics import YOLO
 
 def main(opt: argparse.Namespace) -> None:
     model_path = Path(opt.model)
-    if model_path.suffix != ".pt":
-        raise ValueError("--model must point to a .pt checkpoint built with build_mae_yolo.py")
+    if not model_path.exists():
+        raise FileNotFoundError(f"Model definition '{model_path}' does not exist")
 
     model = YOLO(model_path)
     train_kwargs = dict(
@@ -28,7 +28,7 @@ def main(opt: argparse.Namespace) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--model", type=str, required=True, help="Path to MAE+YOLO .pt checkpoint")
+    parser.add_argument("--model", type=str, required=True, help="Path to MAE+YOLO model YAML or .pt checkpoint")
     parser.add_argument("--data", type=str, required=True, help="Dataset YAML path")
     parser.add_argument("--img", type=int, default=640, help="Image size")
     parser.add_argument("--epochs", type=int, default=50)


### PR DESCRIPTION
## Summary
- wrap the installed ultralytics package so MAE modules are injected into the YOLO registry on import
- expose MaeViTBackbone, MaeSimpleFPN, and the new MaeDetect head through ultralytics_mae.nn and update the MAE YOLOv8 YAML definition
- allow the MAE training helper to accept YAML models and document the registry workflow in the README

## Testing
- `python - <<'PY'
from ultralytics import YOLO
model = YOLO('ultralytics_mae/cfgs/mae_yolov8n.yaml')
print('modules:', [type(m).__name__ for m in model.model.model])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c845b399d08326a2da23afac017be1